### PR TITLE
PGPRO-4978: add outputdir=isolation_output to installcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,15 @@ ISOLATIONCHECKS = corner_cases
 check: isolationcheck
 
 installcheck: submake-isolation
+	$(MKDIR_P) isolation_output
 	$(pg_isolation_regress_installcheck) \
+	  --outputdir=isolation_output \
 	$(ISOLATIONCHECKS)
 
 isolationcheck: | submake-isolation temp-install
 	$(MKDIR_P) isolation_output
 	$(pg_isolation_regress_check) \
-      --outputdir=isolation_output \
+	  --outputdir=isolation_output \
 	$(ISOLATIONCHECKS)
 
 submake-isolation:


### PR DESCRIPTION
This way it will be processed by .gitignore as opposed to outputdir=output_iso
which is the default in pg_isolation_regress_installcheck since PostgreSQL 10.

Also: replace spaces with a tab in the same place of isolationcheck.