### PR TITLE
[PGPRO-5146] Byte manipulations with Size fixed in send/receive_msg_b…

### DIFF
--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -972,8 +972,8 @@ receive_msg_by_parts(shm_mq_handle *mqh, Size *total, void **datap,
 	shm_mq_result mq_receive_result;
 	shm_mq_msg	*buff;
 	int			offset;
-	int			*expected;
-	int			expected_data;
+	Size			*expected;
+	Size			expected_data;
 	Size		len;
 
 	/* Get the expected number of bytes in message */
@@ -981,7 +981,7 @@ receive_msg_by_parts(shm_mq_handle *mqh, Size *total, void **datap,
 	expected_data = *expected;
 	if (mq_receive_result != SHM_MQ_SUCCESS)
 		return mq_receive_result;
-	Assert(len == sizeof(int));
+	Assert(len == sizeof(Size));
 
 	*datap = palloc0(expected_data);
 

--- a/signal_handler.c
+++ b/signal_handler.c
@@ -159,7 +159,7 @@ send_msg_by_parts(shm_mq_handle *mqh, Size nbytes, const void *data)
 	int offset;
 
 	/* Send the expected message length */
-	shm_mq_send(mqh, sizeof(int), &nbytes, false);
+	shm_mq_send(mqh, sizeof(Size), &nbytes, false);
 
 	for (offset = 0; offset < nbytes; offset += bytes_send)
 	{


### PR DESCRIPTION
…y_parts

On 64-bit architectures sizeof(Size) (which is in fact size_t)
not always equals to sizeof(int) so the Size type manipulations in
send/receive_msg_by_parts should be implemented using the Size type
explicitly.

tags: pg_query_state