### PR TITLE
PGPRO-5826: fix build for PostgreSQL 14.1

### DIFF
--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -895,7 +895,7 @@ SendBgWorkerPids(void)
 		msg->pids[i++] = current_pid;
 	}
 
-#if PG_VERSION_NUM <= 140000
+#if PG_VERSION_NUM < 150000
 	shm_mq_send(mqh, msg_len, msg, false);
 #else
 	shm_mq_send(mqh, msg_len, msg, false, true);

--- a/signal_handler.c
+++ b/signal_handler.c
@@ -168,7 +168,7 @@ shm_mq_send_nonblocking(shm_mq_handle *mqh, Size nbytes, const void *data, Size 
 
 	for(i = 0; i < attempts; i++)
 	{
-#if PG_VERSION_NUM <= 140000
+#if PG_VERSION_NUM < 150000
 		res = shm_mq_send(mqh, nbytes, data, true);
 #else
 		res = shm_mq_send(mqh, nbytes, data, true, true);


### PR DESCRIPTION
The previous code did not work for PostgreSQL 14.1 because the signature of the
function shm_mq_send was changed only in PostgreSQL 15devel which has
PG_VERSION_NUM = 150000.