### PR TITLE
fixes in Makefile

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 pg_query_state is released under the PostgreSQL License, a liberal Open Source license, similar to the BSD or MIT licenses.
 
-Copyright (c) 2016-2019, Postgres Professional
+Copyright (c) 2016-2023, Postgres Professional
 Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
 Portions Copyright (c) 1994, The Regents of the University of California
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,19 @@ EXTVERSION = 1.1
 DATA = pg_query_state--1.0--1.1.sql
 DATA_built = $(EXTENSION)--$(EXTVERSION).sql
 PGFILEDESC = "pg_query_state - facility to track progress of plan execution"
-EXTRA_REGRESS_OPTS=--temp-config=$(top_srcdir)/$(subdir)/test.conf
+
 EXTRA_CLEAN = ./isolation_output $(EXTENSION)--$(EXTVERSION).sql \
 	Dockerfile ./tests/*.pyc ./tmp_stress
+
+ISOLATION = corner_cases
+#
+# PG11 doesn't support ISOLATION_OPTS variable. We have to use
+# "CREATE/DROP EXTENTION" command in spec.
+#
+# One day, when we'll get rid of PG11, it will be possible to uncomment this
+# variable and remove "CREATE EXTENTION" from spec.
+#
+# ISOLATION_OPTS = --load-extension=pg_query_state
 
 ifdef USE_PGXS
 PG_CONFIG ?= pg_config
@@ -21,11 +31,17 @@ subdir = contrib/pg_query_state
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
+# need this to provide make check in case of "in source" build
+EXTRA_REGRESS_OPTS=--temp-config=$(top_srcdir)/$(subdir)/test.conf
 endif
 
 $(EXTENSION)--$(EXTVERSION).sql: init.sql
 	cat $^ > $@
 
+#
+# Make conditional targets to save backward compatibility with PG11.
+#
+ifeq ($(MAJORVERSION),11)
 ISOLATIONCHECKS = corner_cases
 
 check: isolationcheck
@@ -46,3 +62,4 @@ submake-isolation:
 	$(MAKE) -C $(top_builddir)/src/test/isolation all
 
 temp-install: EXTRA_INSTALL=contrib/pg_query_state
+endif

--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -2,7 +2,7 @@
  * pg_query_state.c
  *		Extract information about query state from other backend
  *
- * Copyright (c) 2016-2016, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  *	  contrib/pg_query_state/pg_query_state.c
  * IDENTIFICATION

--- a/pg_query_state.h
+++ b/pg_query_state.h
@@ -2,7 +2,7 @@
  * pg_query_state.h
  *		Headers for pg_query_state extension.
  *
- * Copyright (c) 2016-2016, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  contrib/pg_query_state/pg_query_state.h

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright (c) 2019, Postgres Professional
+# Copyright (c) 2019-2023, Postgres Professional
 #
 # supported levels:
 #		* standard

--- a/signal_handler.c
+++ b/signal_handler.c
@@ -2,7 +2,7 @@
  * signal_handler.c
  *		Collect current query state and send it to requestor in custom signal handler
  *
- * Copyright (c) 2016-2016, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  contrib/pg_query_state/signal_handler.c

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,6 @@
 '''
 common.py
-Copyright (c) 2016-2020, Postgres Professional
+Copyright (c) 2016-2023, Postgres Professional
 '''
 
 import psycopg2

--- a/tests/pg_qs_test_runner.py
+++ b/tests/pg_qs_test_runner.py
@@ -1,6 +1,6 @@
 '''
 pg_qs_test_runner.py
-Copyright (c) 2016-2021, Postgres Professional
+Copyright (c) 2016-2023, Postgres Professional
 '''
 
 import argparse

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,6 +1,6 @@
 '''
 test_cases.py
-Copyright (c) 2016-2021, Postgres Professional
+Copyright (c) 2016-2023, Postgres Professional
 '''
 
 import json

--- a/tests/tpcds.py
+++ b/tests/tpcds.py
@@ -1,6 +1,6 @@
 '''
 test_cases.py
-Copyright (c) 2016-2020, Postgres Professional
+Copyright (c) 2016-2023, Postgres Professional
 '''
 
 import os


### PR DESCRIPTION
In order to be ready to the meson build and be able to support parallel installcheck do the following:
 - fix use of USE_MODULE_DB
 - isolation target should be included from the gloabl makefile
 - reorder vars to make it easy to read

+ fix out of source check target

tags: pg_query_state