### PR TITLE
[PGPRO-11597] Redesigned the launch of isolation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,11 @@ env:
     - PG_VERSION=13
     - PG_VERSION=12 LEVEL=hardcore USE_TPCDS=1
     - PG_VERSION=12
-    - PG_VERSION=11
     - PG_VERSION=10
     - PG_VERSION=9.6
 
 matrix:
     allow_failures:
         - env: PG_VERSION=13 LEVEL=hardcore USE_TPCDS=1
-        - env: PG_VERSION=11
         - env: PG_VERSION=10
         - env: PG_VERSION=9.6

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,8 @@ EXTRA_CLEAN = ./isolation_output $(EXTENSION)--$(EXTVERSION).sql \
 	Dockerfile ./tests/*.pyc ./tmp_stress
 
 ISOLATION = corner_cases
-#
-# PG11 doesn't support ISOLATION_OPTS variable. We have to use
-# "CREATE/DROP EXTENTION" command in spec.
-#
-# One day, when we'll get rid of PG11, it will be possible to uncomment this
-# variable and remove "CREATE EXTENTION" from spec.
-#
-# ISOLATION_OPTS = --load-extension=pg_query_state
+
+ISOLATION_OPTS = --load-extension=pg_query_state
 
 ifdef USE_PGXS
 PG_CONFIG ?= pg_config

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install `pg_query_state`, please apply corresponding patches `custom_signal_(
 To do this, run the following commands from the postgresql directory:
 ```
 patch -p1 < path_to_pg_query_state_folder/patches/runtime_explain_(PG_VERSION).patch
-patch -p1 < path_to_pg_query_state_folder/patches/custom_signal_(PG_VERSION).patch
+patch -p1 < path_to_pg_query_state_folder/patches/custom_signals_(PG_VERSION).patch
 ```
 
 Then execute this in the module's directory:

--- a/specs/corner_cases.spec
+++ b/specs/corner_cases.spec
@@ -1,6 +1,5 @@
 setup
 {
-	CREATE EXTENSION pg_query_state;
 	CREATE ROLE alice;
 	CREATE ROLE bob;
 	CREATE ROLE super SUPERUSER;
@@ -31,7 +30,6 @@ teardown
 	DROP ROLE super;
 	DROP ROLE bob;
 	DROP ROLE alice;
-	DROP EXTENSION pg_query_state;
 }
 
 session "s1"


### PR DESCRIPTION
"CREATE/DROP EXTENSION" has been removed from spec. 
Instead, the "ISOLATION_OPTS" variable is used.

Tags: pg_query_state