### PR TITLE
Add progress bar during query execution to track progress.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@
 MODULE_big = pg_query_state
 OBJS = pg_query_state.o signal_handler.o $(WIN32RES)
 EXTENSION = pg_query_state
-EXTVERSION = 1.1
-DATA = pg_query_state--1.0--1.1.sql
+EXTVERSION = 1.2
+DATA = pg_query_state--1.0--1.1.sql \
+	   pg_query_state--1.1--1.2.sql
 DATA_built = $(EXTENSION)--$(EXTVERSION).sql
 PGFILEDESC = "pg_query_state - facility to track progress of plan execution"
 
@@ -13,8 +14,9 @@ EXTRA_CLEAN = ./isolation_output $(EXTENSION)--$(EXTVERSION).sql \
 	Dockerfile ./tests/*.pyc ./tmp_stress
 
 ISOLATION = corner_cases
-
 ISOLATION_OPTS = --load-extension=pg_query_state
+
+TAP_TESTS = 1
 
 ifdef USE_PGXS
 PG_CONFIG ?= pg_config

--- a/README.md
+++ b/README.md
@@ -321,3 +321,117 @@ Do not hesitate to post your issues, questions and new ideas at the [issues](htt
 ## Authors
 [Maksim Milyutin](https://github.com/maksm90)  
 Alexey Kondratov <a.kondratov@postgrespro.ru> Postgres Professional Ltd., Russia
+
+## Function progress\_bar
+```plpgsql
+pg_progress_bar(
+        integer     pid
+) returns FLOAT
+```
+extracts the current query state from backend with specified 'pid'. Then gets the numerical values of the actual rows and total rows and count progress for the whole query tree. Function returns numeric value from 0 to 1 describing the measure of query fulfillment. If there is no information about current state of the query, or the impossibility of counting, the corresponding messages will be displayed.
+
+## Function progress\_bar\_visual
+```plpgsql
+pg_progress_bar_visual(
+        integer     pid,
+        integer     delay
+) returns VOID
+```
+cyclically extracts and print the current query state in numeric value from backend with specified 'pid' every period specified by 'delay' in seconds. This is the looping version of the progress\_bar function that returns void value.
+
+**_Warning_**: Calling role have to be superuser or member of the role whose backend is being called. Otherwise function prints ERROR message `permission denied`.
+
+## Examples
+Assume first backend executes some function:
+```sql
+postgres=# insert into table_name select generate_series(1,10000000);
+```
+Other backend can get the follow output:
+```sql
+postgres=# SELECT pid FROM pg_stat_activity where query like 'insert%';
+  pid
+-------
+ 23877
+(1 row)
+
+postgres=# SELECT pg_progress_bar(23877);
+ pg_progress_bar
+-----------------
+       0.6087927
+(1 row)
+```
+Or continuous version:
+```sql
+postgres=# SELECT pg_progress_bar_visual(23877, 1);
+Progress = 0.043510
+Progress = 0.085242
+Progress = 0.124921
+Progress = 0.168168
+Progress = 0.213803
+Progress = 0.250362
+Progress = 0.292632
+Progress = 0.331454
+Progress = 0.367509
+Progress = 0.407450
+Progress = 0.448646
+Progress = 0.488171
+Progress = 0.530559
+Progress = 0.565558
+Progress = 0.608039
+Progress = 0.645778
+Progress = 0.654842
+Progress = 0.699006
+Progress = 0.735760
+Progress = 0.787641
+Progress = 0.832160
+Progress = 0.871077
+Progress = 0.911858
+Progress = 0.956362
+Progress = 0.995097
+Progress = 1.000000
+ pg_progress_bar_visual
+------------------------
+                      1
+(1 row)
+```
+Also uncountable queries exist. Assume first backend executes some function:
+```sql
+DELETE from table_name;
+```
+Other backend can get the follow output:
+```sql
+postgres=# SELECT pid FROM pg_stat_activity where query like 'delete%';
+  pid
+-------
+ 23877
+(1 row)
+
+postgres=# SELECT pg_progress_bar(23877);
+INFO:  Counting Progress doesn't available
+ pg_progress_bar
+-----------------
+              -1
+(1 row)
+
+postgres=# SELECT pg_progress_bar_visual(23877, 5);
+INFO:  Counting Progress doesn't available
+ pg_progress_bar_visual
+------------------------
+                      -1
+(1 row)
+```
+
+## Reinstallation
+If you already have a module 'pg_query_state' without progress bar functions installed, execute this in the module's directory:
+```
+make install USE_PGXS=1
+```
+It is essential to restart the PostgreSQL instance. After that, execute the following queries in psql:
+```sql
+DROP EXTENSION IF EXISTS pg_query_state;
+CREATE EXTENSION pg_query_state;
+```
+
+## Authors
+Ekaterina Sokolova <e.sokolova@postgrespro.ru> Postgres Professional Ltd., Russia
+Vyacheslav Makarov <v.makarov@postgrespro.ru> Postgres Professional Ltd., Russia

--- a/init.sql
+++ b/init.sql
@@ -15,3 +15,14 @@ CREATE FUNCTION pg_query_state(pid 		integer
 				 , leader_pid integer)
 	AS 'MODULE_PATHNAME'
 	LANGUAGE C STRICT VOLATILE;
+
+CREATE FUNCTION pg_progress_bar(pid integer)
+	RETURNS FLOAT
+	AS 'MODULE_PATHNAME'
+	LANGUAGE C STRICT VOLATILE;
+
+CREATE FUNCTION pg_progress_bar_visual(pid		integer
+								  , delay	integer = 1)
+	RETURNS FLOAT
+	AS 'MODULE_PATHNAME', 'pg_progress_bar'
+	LANGUAGE C STRICT VOLATILE;

--- a/pg_query_state--1.1--1.2.sql
+++ b/pg_query_state--1.1--1.2.sql
@@ -1,0 +1,14 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION pg_query_state UPDATE TO '1.2'" to load this file. \quit
+
+CREATE FUNCTION pg_progress_bar(pid integer)
+	RETURNS FLOAT
+	AS 'MODULE_PATHNAME'
+	LANGUAGE C STRICT VOLATILE;
+
+CREATE FUNCTION pg_progress_bar_visual(pid		integer
+								  , delay	integer = 1)
+	RETURNS FLOAT
+	AS 'MODULE_PATHNAME', 'pg_progress_bar'
+	LANGUAGE C STRICT VOLATILE;
+    

--- a/pg_query_state.control
+++ b/pg_query_state.control
@@ -1,5 +1,5 @@
 # pg_query_state extension
 comment = 'tool for inspection query progress'
-default_version = '1.1'
+default_version = '1.2'
 module_pathname = '$libdir/pg_query_state'
 relocatable = true

--- a/t/test_bad_progress_bar.pl
+++ b/t/test_bad_progress_bar.pl
@@ -1,0 +1,115 @@
+# pg_query_state/t/test_bad_progress_bar.pl
+#
+# Check uncorrect launches of functions pg_progress_bar(pid)
+# and pg_progress_bar_visual(pid, delay)
+
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+# List of checks for bad cases:
+#     1) appealing to a bad pid
+#  ------- requires DBI and DBD::Pg modules -------
+#     2) extracting the state of the process itself
+
+my $node;
+my $dbh_status;
+my $pid_status;
+
+sub bad_pid
+{
+        note('Extracting from bad pid');
+        my $stderr;
+        $node->psql('postgres', 'SELECT * from pg_progress_bar(-1)', stderr => \$stderr);
+        is ($stderr, 'psql:<stdin>:1: ERROR:  backend with pid=-1 not found', "appealing to a bad pid for pg_progress_bar");
+        $node->psql('postgres', 'SELECT * from pg_progress_bar(-1)_visual', stderr => \$stderr);
+        is ($stderr, 'psql:<stdin>:1: ERROR:  backend with pid=-1 not found', "appealing to a bad pid for pg_progress_bar_visual");
+}
+
+sub self_status
+{
+        note('Extracting your own status');
+        $dbh_status->do('SELECT * from pg_progress_bar(' . $pid_status . ')');
+        is($dbh_status->errstr, 'ERROR:  attempt to extract state of current process', "extracting the state of the process itself for pg_progress_bar");
+        $dbh_status->do('SELECT * from pg_progress_bar_visual(' . $pid_status . ')');
+        is($dbh_status->errstr, 'ERROR:  attempt to extract state of current process', "extracting the state of the process itself for pg_progress_bar_visual");
+}
+
+# start backend for function pg_progress_bar
+
+my $pg_15_modules;
+
+BEGIN
+{
+	$pg_15_modules = eval
+	{
+		require PostgreSQL::Test::Cluster;
+		require PostgreSQL::Test::Utils;
+		return 1;
+	};
+
+	unless (defined $pg_15_modules)
+	{
+		$pg_15_modules = 0;
+
+		require PostgresNode;
+		require TestLib;
+	}
+}
+
+note('PostgreSQL 15 modules are used: ' . ($pg_15_modules ? 'yes' : 'no'));
+
+if ($pg_15_modules)
+{
+	$node = PostgreSQL::Test::Cluster->new("master");
+}
+else
+{
+	$node = PostgresNode->get_new_node("master");
+}
+
+$node->init;
+$node->start;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_query_state'");
+$node->restart;
+$node->psql('postgres', 'CREATE EXTENSION pg_query_state;');
+
+# 2 tests for 1 case
+bad_pid();
+
+# Check whether we have both DBI and DBD::pg
+
+my $dbdpg_rc = eval
+{
+        require DBI;
+        require DBD::Pg;
+        1;
+};
+
+$dbdpg_rc = 0 unless defined $dbdpg_rc;
+
+if ($dbdpg_rc != 1)
+{
+        diag('DBI and DBD::Pg are not available, skip 2/4 tests');
+}
+
+SKIP: {
+        skip "DBI and DBD::Pg are not available", 2 if ($dbdpg_rc != 1);
+
+        DBD::Pg->import(':async');
+        $dbh_status = DBI->connect('DBI:Pg:' . $node->connstr($_));
+        if ( !defined $dbh_status )
+        {
+                die "Cannot connect to database for dbh with pg_progress_bar\n";
+        }
+
+        $pid_status = $dbh_status->{pg_pid};
+
+        # 2 tests for 2 case
+        self_status();
+
+        $dbh_status->disconnect;
+}
+
+$node->stop('fast');
+

--- a/tests/pg_qs_test_runner.py
+++ b/tests/pg_qs_test_runner.py
@@ -70,6 +70,7 @@ tests = [
 	test_formats,
 	test_timing_buffers_conflicts,
 	test_insert_on_conflict,
+	test_progress_bar,
 ]
 
 def setup(con):

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -408,3 +408,18 @@ def test_timing_buffers_conflicts(config):
 							 and 'WARNING:  buffers statistics disabled\n' in notices
 
 	common.n_close((acon,))
+
+def test_progress_bar(config):
+	"""test pg_progress_bar of simple query"""
+
+	acon, = common.n_async_connect(config)
+	query = 'select * from foo join bar on foo.c1=bar.c1'
+
+	qs, notices = common.onetime_progress_bar(config, acon, query)
+	assert qs[0][0] >= 0 and qs[0][0] < 1
+	first_qs = qs[0][0]
+
+	qs, _ = common.onetime_progress_bar(config, acon, query)
+	assert qs[0][0] >= first_qs and qs[0][0] < 1
+
+	common.n_close((acon,))


### PR DESCRIPTION
Progress bar is run-time SQL-query progress indicator.

Function pg_progress_bar(pid) extracts the current query state from backend with specified 'pid'. Then gets the numerical values of the actual rows and total rows and count progress for the whole query tree. Function returns numeric value from 0 to 1 describing the measure of query fulfillment. This function can be used to be embedded in the PostgreSQL GUI.

To intuitively track progress without using a graphical client, you can use the additionally implemented function pg_progress_bar_visual(pid, delay). It prints state every period specified by 'delay' (in seconds).

Increase version to 1.2 due to init.sql change.