### PR TITLE
PGPRO-10866: Add static decoration to avoid error:

### DIFF
--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -101,8 +101,8 @@ static List *GetRemoteBackendQueryStates(PGPROC *leader,
 										 ExplainFormat format);
 
 /* Shared memory variables */
-shm_toc			   *toc = NULL;
-RemoteUserIdResult *counterpart_userid = NULL;
+static shm_toc			   *toc = NULL;
+static RemoteUserIdResult *counterpart_userid = NULL;
 pg_qs_params   	   *params = NULL;
 shm_mq 			   *mq = NULL;
 


### PR DESCRIPTION
"no previous extern declaration for non-static variable [-Wmissing-variable-declarations]".

Tags: pg_query_state