### PR TITLE
PGPRO-10866: Add static decoration to avoid error:

### DIFF
--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -101,8 +101,8 @@ static List *GetRemoteBackendQueryStates(PGPROC *leader,
 										 ExplainFormat format);
 
 /* Shared memory variables */
-shm_toc			   *toc = NULL;
-RemoteUserIdResult *counterpart_userid = NULL;
+static shm_toc			  *toc = NULL;
+static RemoteUserIdResult *counterpart_userid = NULL;
 pg_qs_params	   *params = NULL;
 shm_mq			   *mq = NULL;
 


### PR DESCRIPTION
"no previous extern declaration for non-static variable [-Wmissing-variable-declarations]".

Return back changes from the similar commit
d01ea74a4b4c8f76f110badbcbc40b30308030f0 (PGPRO-10866: Add static decoration to avoid error) as they were reverted in the commit
c927d0c41487d8b79c081c22b442bbf96dcfea6e (Add progress bar during query execution to track progress. (#63)).