### PR TITLE
PGPRO-12044: Use vanilla ExecutorRun hook simplification.

### DIFF
--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -51,7 +51,7 @@ void		_PG_init(void);
 
 /* hooks defined in this module */
 static void qs_ExecutorStart(QueryDesc *queryDesc, int eflags);
-#if PG_VERSION_NUM < 100000
+#if PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 180000
 static void qs_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count);
 #else
 static void qs_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
@@ -296,7 +296,7 @@ qs_ExecutorStart(QueryDesc *queryDesc, int eflags)
  * 		Catch any fatal signals
  */
 static void
-#if PG_VERSION_NUM < 100000
+#if PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 180000
 qs_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count)
 #else
 qs_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
@@ -308,7 +308,7 @@ qs_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 	PG_TRY();
 	{
 		if (prev_ExecutorRun)
-#if PG_VERSION_NUM < 100000
+#if PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 180000
 			prev_ExecutorRun(queryDesc, direction, count);
 		else
 			standard_ExecutorRun(queryDesc, direction, count);

--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -101,8 +101,8 @@ static List *GetRemoteBackendQueryStates(PGPROC *leader,
 										 ExplainFormat format);
 
 /* Shared memory variables */
-shm_toc			   *toc = NULL;
-RemoteUserIdResult *counterpart_userid = NULL;
+static shm_toc			  *toc = NULL;
+static RemoteUserIdResult *counterpart_userid = NULL;
 pg_qs_params	   *params = NULL;
 shm_mq			   *mq = NULL;
 


### PR DESCRIPTION
Caused by:
  - 3eea7a0c97e94f9570af87317ce3f6a41eb62768 (PostgreSQL)
    Simplify executor's determination of whether to use parallelism.
  - https://github.com/postgrespro/pg_query_state/commit/138323be327fd35010074e03bfb382872a21c461 (pg_query_state subtree)
    Merged versions 9.6 and 10
 Tags: pg_query_state

Author: Anton A. Melnikov