### PR TITLE
pg_query_state code should be stable to the struct LOCKTAG extension.

### DIFF
--- a/pg_query_state.c
+++ b/pg_query_state.c
@@ -419,6 +419,7 @@ void
 LockShmem(LOCKTAG *tag, uint32 key)
 {
 	LockAcquireResult result;
+	memset(tag, 0, sizeof(LOCKTAG));
 	tag->locktag_field1 = PG_QS_MODULE_KEY;
 	tag->locktag_field2 = key;
 	tag->locktag_field3 = 0;


### PR DESCRIPTION
LOCKTAG is used in hash calculations, so if new field is added to LOCKTAG and this field is not initialized in pg_query_state internals, as the result, the hashcode of LOCKTAG will have different values for two independent calculations.